### PR TITLE
Merge codex/auth-lifecycle-recovery-sdk into master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehive",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehive",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehive",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "SDK for Rehive Platform and Extensions",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehive",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "SDK for Rehive Platform and Extensions",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/auth/auth-provider.test.tsx
+++ b/src/__tests__/auth/auth-provider.test.tsx
@@ -44,12 +44,18 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   </AuthProvider>
 );
 
+const describeAuthUser = (authUser: unknown): string => {
+  if (authUser === undefined) return 'undefined';
+  if (authUser === null) return 'null';
+  return (authUser as { user: { id: string } }).user.id;
+};
+
 const TestComponent = () => {
   const auth = useAuth();
   return (
     <div>
       <span data-testid="loading">{auth.authLoading.toString()}</span>
-      <span data-testid="user">{auth.authUser?.user.id || 'null'}</span>
+      <span data-testid="user">{describeAuthUser(auth.authUser)}</span>
       <span data-testid="error">{auth.authError?.message || 'null'}</span>
     </div>
   );
@@ -83,18 +89,20 @@ describe('AuthProvider', () => {
     expect(getByTestId('error')).toBeInTheDocument();
   });
 
-  it('should initialize auth state and settle', async () => {
+  it('should expose authUser as undefined during bootstrap and null after hydration', async () => {
     const { getByTestId } = render(
       <TestWrapper>
         <TestComponent />
       </TestWrapper>,
     );
 
-    expect(getByTestId('user')).toHaveTextContent('null');
+    expect(getByTestId('user')).toHaveTextContent('undefined');
 
     await waitFor(() => {
       expect(getByTestId('loading')).toHaveTextContent('false');
     });
+
+    expect(getByTestId('user')).toHaveTextContent('null');
   });
 
   it('should handle login through useAuth hook', async () => {

--- a/src/__tests__/auth/auth-provider.test.tsx
+++ b/src/__tests__/auth/auth-provider.test.tsx
@@ -83,14 +83,13 @@ describe('AuthProvider', () => {
     expect(getByTestId('error')).toBeInTheDocument();
   });
 
-  it('should initialize with loading state', async () => {
+  it('should initialize auth state and settle', async () => {
     const { getByTestId } = render(
       <TestWrapper>
         <TestComponent />
       </TestWrapper>,
     );
 
-    expect(getByTestId('loading')).toHaveTextContent('true');
     expect(getByTestId('user')).toHaveTextContent('null');
 
     await waitFor(() => {
@@ -230,6 +229,19 @@ describe('AuthProvider', () => {
     expect(typeof result.current.auth.login).toBe('function');
     expect(typeof result.current.auth.registerCompany).toBe('function');
     expect(typeof result.current.auth.logout).toBe('function');
+  });
+
+  it('should expose auth status and recovery state', async () => {
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.authLoading).toBe(false);
+    });
+
+    expect(result.current.authStatus).toBe('unauthenticated');
+    expect(result.current.authRecovery.pending).toBe(false);
   });
 
   it('should throw error when used outside AuthProvider', () => {

--- a/src/__tests__/auth/create-auth.test.ts
+++ b/src/__tests__/auth/create-auth.test.ts
@@ -352,6 +352,45 @@ describe('createAuth', () => {
       expect(auth.getStatus()).toBe('recoverable');
       expect(auth.getState().recovery.pending).toBe(true);
     });
+
+    it('should refresh and keep the session when validation hits an unauthorized error', async () => {
+      const auth = createAuth({ storage: 'memory', enableCrossTabSync: false });
+
+      await auth.login({
+        user: 'test@example.com',
+        password: 'password123',
+        company: 'test-co',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          json: async () => ({ message: 'Unauthorized' }),
+          text: async () => JSON.stringify({ message: 'Unauthorized' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              id: 'user-123',
+              email: 'test@example.com',
+              company: 'test-co',
+            },
+          }),
+          text: async () => '',
+        });
+
+      const isValid = await auth.validateActiveSession({
+        retryCount: 0,
+      });
+
+      expect(isValid).toBe(true);
+      expect(mockAuthRefreshCreate).toHaveBeenCalledTimes(1);
+      expect(auth.getStatus()).toBe('authenticated');
+      expect(auth.getActiveSession()?.token).toBe(mockLoginResponse.data.token);
+    });
   });
 
   describe('listeners', () => {

--- a/src/__tests__/auth/create-auth.test.ts
+++ b/src/__tests__/auth/create-auth.test.ts
@@ -11,6 +11,7 @@ const mockAuthRegister = jest.fn();
 const mockAuthRegisterCompany = jest.fn();
 const mockAuthLogout = jest.fn();
 const mockAuthRefreshCreate = jest.fn();
+const mockFetch = jest.fn();
 
 jest.mock('../../platform/user/openapi-ts/sdk.gen.js', () => ({
   authLogin: (...args: any[]) => mockAuthLogin(...args),
@@ -29,6 +30,7 @@ import { createAuth } from '../../auth/create-auth.js';
 describe('createAuth', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
 
     mockAuthLogin.mockImplementation(async (opts: any) => {
       if (opts?.body?.password === 'wrong-password') {
@@ -40,6 +42,18 @@ describe('createAuth', () => {
     mockAuthRegisterCompany.mockResolvedValue(mockRegisterCompanyResponse);
     mockAuthLogout.mockResolvedValue(mockLogoutResponse);
     mockAuthRefreshCreate.mockResolvedValue(mockRefreshResponse);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          id: 'user-123',
+          email: 'test@example.com',
+          company: 'test-co',
+        },
+      }),
+      text: async () => '',
+    });
   });
 
   describe('initialization', () => {
@@ -270,6 +284,73 @@ describe('createAuth', () => {
 
       const nonExistent = auth.getSessionsByCompany('company-2');
       expect(nonExistent).toHaveLength(0);
+    });
+  });
+
+  describe('session lifecycle helpers', () => {
+    it('should import a token as the active session', async () => {
+      const auth = createAuth({ storage: 'memory', enableCrossTabSync: false });
+
+      const session = await auth.importToken('legacy-token', {
+        sessionDuration: 3600,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rehive.com/3/user/',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Token legacy-token',
+          }),
+        }),
+      );
+      expect(session.token).toBe('legacy-token');
+      expect(session.company).toBe('test-co');
+      expect(auth.getActiveSession()?.token).toBe('legacy-token');
+      expect(auth.getStatus()).toBe('authenticated');
+    });
+
+    it('should expose recoverable state after expiring the active session', async () => {
+      const auth = createAuth({ storage: 'memory', enableCrossTabSync: false });
+
+      const loginResponse1 = {
+        ...mockLoginResponse,
+        data: {
+          ...mockLoginResponse.data,
+          user: { ...mockLoginResponse.data.user, id: 'user-1' },
+          token: 'token-1',
+        },
+      };
+      const loginResponse2 = {
+        ...mockLoginResponse,
+        data: {
+          ...mockLoginResponse.data,
+          user: { ...mockLoginResponse.data.user, id: 'user-2' },
+          token: 'token-2',
+        },
+      };
+      mockAuthLogin
+        .mockResolvedValueOnce(loginResponse1)
+        .mockResolvedValueOnce(loginResponse2);
+
+      await auth.login({
+        user: 'one@example.com',
+        password: 'password123',
+        company: 'company-1',
+      });
+      await auth.login({
+        user: 'two@example.com',
+        password: 'password123',
+        company: 'company-2',
+      });
+
+      const recovery = await auth.expireActiveSession();
+
+      expect(recovery.pending).toBe(true);
+      expect(recovery.expiredSession?.token).toBe('token-2');
+      expect(recovery.remainingSessions).toHaveLength(1);
+      expect(recovery.remainingSessions[0].token).toBe('token-1');
+      expect(auth.getStatus()).toBe('recoverable');
+      expect(auth.getState().recovery.pending).toBe(true);
     });
   });
 

--- a/src/auth/create-auth.ts
+++ b/src/auth/create-auth.ts
@@ -14,10 +14,16 @@ import type {
 import { WebStorageAdapter, MemoryStorageAdapter } from './core/storage-adapters.js';
 import { ApiError, normalizeFetch } from '../shared/api-utils.js';
 import type {
+  AuthEvent,
+  AuthEventListener,
+  AuthRecoveryState,
   AuthSession,
+  AuthSnapshot,
   AuthState,
-  SessionListener,
+  AuthStateListener,
+  AuthStatus,
   ErrorListener,
+  SessionListener,
   StorageAdapter,
 } from './types/index.js';
 
@@ -43,6 +49,21 @@ export type RegisterParams = {
 
 export type RegisterCompanyParams = RegisterCompanyRequestWritable;
 
+export interface ImportTokenOptions {
+  company?: string;
+  expires?: number;
+  sessionDuration?: number;
+}
+
+export interface ValidateSessionOptions {
+  retryCount?: number;
+  retryDelayMs?: number;
+}
+
+export type SessionPatch =
+  | Partial<AuthSession>
+  | ((session: AuthSession) => AuthSession);
+
 export interface AuthConfig {
   baseUrl?: string;
   storage?: 'local' | 'memory' | StorageAdapter;
@@ -61,11 +82,25 @@ export interface Auth {
   getActiveSession(): AuthSession | null;
   getSessions(): AuthSession[];
   getSessionsByCompany(company: string): AuthSession[];
+  getState(): AuthSnapshot;
+  getStatus(): AuthStatus;
+  getRecoveryState(): AuthRecoveryState;
   switchToSession(userId: string, company?: string): Promise<AuthSession | null>;
   clearAllSessions(): Promise<void>;
   deleteChallenge(challengeId: string): Promise<void>;
+  importToken(token: string, options?: ImportTokenOptions): Promise<AuthSession>;
+  validateActiveSession(options?: ValidateSessionOptions): Promise<boolean>;
+  syncActiveSessionUser(): Promise<AuthSession | null>;
+  updateSession(
+    userId: string,
+    company: string | undefined,
+    patch: SessionPatch,
+  ): Promise<AuthSession | null>;
+  expireActiveSession(): Promise<AuthRecoveryState>;
   subscribe(listener: SessionListener): () => void;
   subscribeToErrors(listener: ErrorListener): () => void;
+  subscribeToState(listener: AuthStateListener): () => void;
+  subscribeToEvents(listener: AuthEventListener): () => void;
   readonly baseUrl: string;
 }
 
@@ -106,46 +141,184 @@ function errorHandlingFetch(baseFetch: typeof fetch): typeof fetch {
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getSessionCompany(session: AuthSession): string | undefined {
+  return session.company ?? session.user?.company;
+}
+
+function cloneSessions(sessions: AuthSession[]): AuthSession[] {
+  return [...sessions];
+}
+
 export function createAuth(config: AuthConfig = {}): Auth {
   const baseUrl = config.baseUrl || 'https://api.rehive.com';
   const storage = resolveStorage(config.storage);
   const permanentToken = config.token;
   const enableCrossTabSync = config.enableCrossTabSync ?? true;
   const storageKey = 'rehive_auth_state';
+  const baseFetch = normalizeFetch(globalThis.fetch);
 
   const client = createClient({
     baseUrl,
     responseStyle: 'data' as const,
-    fetch: errorHandlingFetch(normalizeFetch(globalThis.fetch)),
+    fetch: errorHandlingFetch(baseFetch),
   });
 
   let sessions: AuthSession[] = [];
   let activeSessionIndex = -1;
   let sessionListeners: SessionListener[] = [];
   let errorListeners: ErrorListener[] = [];
+  let stateListeners: AuthStateListener[] = [];
+  let eventListeners: AuthEventListener[] = [];
   let refreshPromise: Promise<void> | null = null;
   let isRefreshing = false;
   let loadAuthStatePromise: Promise<AuthState> | null = null;
   let initialized = false;
+  let lastError: Error | null = null;
+  let lastExpiredSession: AuthSession | null = null;
 
   function isTokenExpired(expires: number): boolean {
     return Date.now() >= expires - 30 * 1000;
   }
 
-  function getActiveSession(): AuthSession | null {
-    if (activeSessionIndex >= 0 && activeSessionIndex < sessions.length) {
-      return sessions[activeSessionIndex];
+  function getActiveSessionFromState(state: AuthState): AuthSession | null {
+    if (
+      state.activeSessionIndex >= 0 &&
+      state.activeSessionIndex < state.sessions.length
+    ) {
+      return state.sessions[state.activeSessionIndex];
     }
     return null;
   }
 
-  function notifySessionListeners(): void {
-    const session = getActiveSession();
-    sessionListeners.forEach((listener) => listener(session));
+  function getCurrentState(): AuthState {
+    return {
+      sessions: cloneSessions(sessions),
+      activeSessionIndex,
+    };
   }
 
-  function notifyErrorListeners(error: Error | null): void {
-    errorListeners.forEach((listener) => listener(error));
+  function getActiveSession(): AuthSession | null {
+    return getActiveSessionFromState(getCurrentState());
+  }
+
+  function buildRecoveryState(state: AuthState = getCurrentState()): AuthRecoveryState {
+    const session = getActiveSessionFromState(state);
+    const pending = !permanentToken && !session && state.sessions.length > 0;
+
+    return {
+      pending,
+      expiredSession: pending ? lastExpiredSession : null,
+      remainingSessions: pending ? cloneSessions(state.sessions) : [],
+    };
+  }
+
+  function getStatus(state: AuthState = getCurrentState()): AuthStatus {
+    if (!initialized && !permanentToken) {
+      return 'loading';
+    }
+    if (isRefreshing) {
+      return 'refreshing';
+    }
+    if (permanentToken) {
+      return 'authenticated';
+    }
+    if (getActiveSessionFromState(state)) {
+      return 'authenticated';
+    }
+    if (state.sessions.length > 0) {
+      return 'recoverable';
+    }
+    return 'unauthenticated';
+  }
+
+  function getState(): AuthSnapshot {
+    const state = getCurrentState();
+    return {
+      status: getStatus(state),
+      session: getActiveSessionFromState(state),
+      sessions: state.sessions,
+      activeSessionIndex: state.activeSessionIndex,
+      isRefreshing,
+      initialized: initialized || !!permanentToken,
+      error: lastError,
+      recovery: buildRecoveryState(state),
+    };
+  }
+
+  function emit(event: Omit<AuthEvent, 'snapshot'>): void {
+    const snapshot = getState();
+    const payload: AuthEvent = {
+      ...event,
+      snapshot,
+    };
+    eventListeners.forEach((listener) => listener(payload));
+  }
+
+  function notifyAll(event?: Omit<AuthEvent, 'snapshot'>): void {
+    const snapshot = getState();
+    sessionListeners.forEach((listener) => listener(snapshot.session));
+    errorListeners.forEach((listener) => listener(snapshot.error));
+    stateListeners.forEach((listener) => listener(snapshot));
+
+    if (event) {
+      emit(event);
+    }
+  }
+
+  function setError(error: Error | null): void {
+    lastError = error;
+  }
+
+  async function persistState(state: AuthState): Promise<void> {
+    if (permanentToken) {
+      return;
+    }
+
+    await storage.setItem(storageKey, JSON.stringify(state));
+  }
+
+  async function applyState(
+    state: AuthState,
+    options: {
+      clearExpiredSession?: boolean;
+      expiredSession?: AuthSession | null;
+      error?: Error | null;
+      event?: Omit<AuthEvent, 'snapshot'>;
+    } = {},
+  ): Promise<void> {
+    sessions = cloneSessions(state.sessions);
+    activeSessionIndex =
+      state.activeSessionIndex >= 0 && state.activeSessionIndex < sessions.length
+        ? state.activeSessionIndex
+        : -1;
+
+    if (options.clearExpiredSession || activeSessionIndex >= 0 || sessions.length === 0) {
+      lastExpiredSession = null;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'expiredSession')) {
+      lastExpiredSession = options.expiredSession ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'error')) {
+      setError(options.error ?? null);
+    }
+
+    try {
+      await persistState({
+        sessions,
+        activeSessionIndex,
+      });
+    } catch (error) {
+      console.error('Failed to save auth state:', error);
+      if (!lastError && error instanceof Error) {
+        setError(error);
+      }
+    }
+
+    notifyAll(options.event);
   }
 
   async function loadAuthState(): Promise<AuthState> {
@@ -168,9 +341,17 @@ export function createAuth(config: AuthConfig = {}): Auth {
       } catch (error) {
         console.error('Failed to load auth state:', error);
       }
+
       sessions = state.sessions;
-      activeSessionIndex = state.activeSessionIndex;
-      return state;
+      activeSessionIndex =
+        state.activeSessionIndex >= 0 && state.activeSessionIndex < state.sessions.length
+          ? state.activeSessionIndex
+          : -1;
+
+      return {
+        sessions: cloneSessions(sessions),
+        activeSessionIndex,
+      };
     })();
 
     try {
@@ -180,39 +361,44 @@ export function createAuth(config: AuthConfig = {}): Auth {
     }
   }
 
-  async function saveAuthState(state: AuthState): Promise<void> {
-    try {
-      await storage.setItem(storageKey, JSON.stringify(state));
-      sessions = state.sessions;
-      activeSessionIndex = state.activeSessionIndex;
-      notifySessionListeners();
-    } catch (error) {
-      console.error('Failed to save auth state:', error);
-    }
-  }
-
   function setupCrossTabSync(): void {
     if (typeof window !== 'undefined') {
       window.addEventListener('storage', (event: StorageEvent) => {
-        if (event.key === storageKey && event.newValue) {
-          try {
-            const newState = JSON.parse(event.newValue);
-            sessions = Array.isArray(newState.sessions) ? newState.sessions : [];
-            activeSessionIndex =
-              typeof newState.activeSessionIndex === 'number'
-                ? newState.activeSessionIndex
-                : -1;
-            notifySessionListeners();
-          } catch (error) {
-            console.error('Failed to sync auth state from storage event:', error);
-          }
+        if (event.key !== storageKey) {
+          return;
+        }
+
+        if (!event.newValue) {
+          void applyState(
+            { sessions: [], activeSessionIndex: -1 },
+            { clearExpiredSession: true },
+          );
+          return;
+        }
+
+        try {
+          const newState = JSON.parse(event.newValue);
+          void applyState(
+            {
+              sessions: Array.isArray(newState.sessions) ? newState.sessions : [],
+              activeSessionIndex:
+                typeof newState.activeSessionIndex === 'number'
+                  ? newState.activeSessionIndex
+                  : -1,
+            },
+            {},
+          );
+        } catch (error) {
+          console.error('Failed to sync auth state from storage event:', error);
         }
       });
     }
   }
 
   async function initialize(): Promise<void> {
-    if (initialized) return;
+    if (initialized) {
+      return;
+    }
     initialized = true;
 
     if (!permanentToken) {
@@ -220,11 +406,82 @@ export function createAuth(config: AuthConfig = {}): Auth {
         setupCrossTabSync();
       }
       await loadAuthState();
-      notifySessionListeners();
     }
+
+    notifyAll({ type: 'initialized' });
   }
 
-  // Kick off initialization (non-blocking)
+  async function fetchUserForToken(token: string): Promise<any> {
+    const response = await baseFetch(`${baseUrl.replace(/\/$/, '')}/3/user/`, {
+      headers: {
+        Authorization: `Token ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorJson: any = null;
+      try {
+        errorJson = JSON.parse(errorText);
+      } catch {
+        // not JSON
+      }
+
+      throw new ApiError({
+        status: response.status,
+        error: errorJson || errorText,
+        message:
+          errorJson?.error ||
+          errorJson?.message ||
+          'A server error occurred. HTTPStatus: ' + response.status,
+      });
+    }
+
+    const payload = await response.json();
+    return payload?.data ?? payload;
+  }
+
+  async function upsertSession(
+    newSession: AuthSession,
+    eventType: AuthEvent['type'],
+  ): Promise<AuthSession> {
+    await initialize();
+    const currentState = await loadAuthState();
+    const sessionCompany = getSessionCompany(newSession);
+    const existingIdx = currentState.sessions.findIndex(
+      (session) =>
+        session.user.id === newSession.user.id &&
+        getSessionCompany(session) === sessionCompany,
+    );
+
+    let nextState: AuthState;
+    if (existingIdx >= 0) {
+      const updatedSessions = cloneSessions(currentState.sessions);
+      updatedSessions[existingIdx] = newSession;
+      nextState = {
+        sessions: updatedSessions,
+        activeSessionIndex: existingIdx,
+      };
+    } else {
+      nextState = {
+        sessions: [...currentState.sessions, newSession],
+        activeSessionIndex: currentState.sessions.length,
+      };
+    }
+
+    await applyState(nextState, {
+      clearExpiredSession: true,
+      error: null,
+      event: {
+        type: eventType,
+        session: newSession,
+      },
+    });
+
+    return newSession;
+  }
+
   if (!permanentToken) {
     initialize().catch(console.error);
   }
@@ -244,40 +501,25 @@ export function createAuth(config: AuthConfig = {}): Auth {
       const result: any = await authLogin({ client, body, throwOnError: true });
       const data = result?.data ?? result;
 
-      const newSession: AuthSession = {
-        user: data.user,
-        token: data.token,
-        refresh_token: data.refresh_token,
-        challenges: data.challenges,
-        expires: data.expires,
-        session_duration: sessionDuration,
-        company: params.company,
-      };
-
-      const currentState = await loadAuthState();
-      const existingIdx = currentState.sessions.findIndex(
-        (s: AuthSession) =>
-          s.user.id === newSession.user.id && s.company === newSession.company,
+      return await upsertSession(
+        {
+          user: data.user,
+          token: data.token,
+          refresh_token: data.refresh_token,
+          challenges: data.challenges,
+          expires: data.expires,
+          session_duration: sessionDuration,
+          company: params.company,
+        },
+        'login',
       );
-
-      let newState: AuthState;
-      if (existingIdx !== -1) {
-        const updated = [...currentState.sessions];
-        updated[existingIdx] = newSession;
-        newState = { ...currentState, sessions: updated, activeSessionIndex: existingIdx };
-      } else {
-        newState = {
-          sessions: [...currentState.sessions, newSession],
-          activeSessionIndex: currentState.sessions.length,
-        };
-      }
-
-      await saveAuthState(newState);
-      notifyErrorListeners(null);
-      return newSession;
     } catch (e) {
       const error = e instanceof ApiError ? e : new Error('Login failed');
-      notifyErrorListeners(error);
+      setError(error);
+      notifyAll({
+        type: 'error',
+        error,
+      });
       throw e;
     }
   }
@@ -303,28 +545,25 @@ export function createAuth(config: AuthConfig = {}): Auth {
       const result: any = await authRegister({ client, body, throwOnError: true });
       const data = result?.data ?? result;
 
-      const newSession: AuthSession = {
-        user: data.user,
-        token: data.token,
-        refresh_token: data.refresh_token,
-        challenges: data.challenges,
-        expires: data.expires,
-        session_duration: sessionDuration,
-        company: params.company,
-      };
-
-      const currentState = await loadAuthState();
-      const newState: AuthState = {
-        sessions: [...currentState.sessions, newSession],
-        activeSessionIndex: currentState.sessions.length,
-      };
-
-      await saveAuthState(newState);
-      notifyErrorListeners(null);
-      return newSession;
+      return await upsertSession(
+        {
+          user: data.user,
+          token: data.token,
+          refresh_token: data.refresh_token,
+          challenges: data.challenges,
+          expires: data.expires,
+          session_duration: sessionDuration,
+          company: params.company,
+        },
+        'register',
+      );
     } catch (e) {
       const error = e instanceof ApiError ? e : new Error('Registration failed');
-      notifyErrorListeners(error);
+      setError(error);
+      notifyAll({
+        type: 'error',
+        error,
+      });
       throw e;
     }
   }
@@ -332,47 +571,45 @@ export function createAuth(config: AuthConfig = {}): Auth {
   async function registerCompanyFn(params: RegisterCompanyParams): Promise<AuthSession> {
     await initialize();
     try {
-      const body: RegisterCompanyRequestWritable = params;
-      const result: any = await authRegisterCompany({ client, body, throwOnError: true });
+      const result: any = await authRegisterCompany({
+        client,
+        body: params,
+        throwOnError: true,
+      });
       const data = result?.data ?? result;
+      const company =
+        typeof params.company === 'string'
+          ? params.company
+          : (params.company as any)?.id;
 
-      const newSession: AuthSession = {
-        user: data.user,
-        token: data.token,
-        refresh_token: data.refresh_token,
-        challenges: data.challenges,
-        expires: data.expires,
-        session_duration: 900,
-        company: typeof params.company === 'string' ? params.company : (params.company as any)?.id,
-      };
-
-      const currentState = await loadAuthState();
-      const newState: AuthState = {
-        sessions: [...currentState.sessions, newSession],
-        activeSessionIndex: currentState.sessions.length,
-      };
-
-      await saveAuthState(newState);
-      notifyErrorListeners(null);
-      return newSession;
+      return await upsertSession(
+        {
+          user: data.user,
+          token: data.token,
+          refresh_token: data.refresh_token,
+          challenges: data.challenges,
+          expires: data.expires,
+          session_duration: 900,
+          company,
+        },
+        'register-company',
+      );
     } catch (e) {
-      const error = e instanceof ApiError ? e : new Error('Company registration failed');
-      notifyErrorListeners(error);
+      const error =
+        e instanceof ApiError ? e : new Error('Company registration failed');
+      setError(error);
+      notifyAll({
+        type: 'error',
+        error,
+      });
       throw e;
     }
   }
 
   async function logout(): Promise<void> {
+    await initialize();
     const currentState = await loadAuthState();
-    const session = currentState.sessions[currentState.activeSessionIndex];
-
-    const newState: AuthState = {
-      ...currentState,
-      sessions: currentState.sessions.filter(
-        (_: AuthSession, i: number) => i !== currentState.activeSessionIndex,
-      ),
-      activeSessionIndex: -1,
-    };
+    const session = getActiveSessionFromState(currentState);
 
     if (session?.token) {
       try {
@@ -383,19 +620,34 @@ export function createAuth(config: AuthConfig = {}): Auth {
           throwOnError: true,
         });
       } catch {
-        // Continue with local logout even if API call fails
+        // Continue with local logout even if API call fails.
       }
     }
 
-    await saveAuthState(newState);
-    notifyErrorListeners(null);
+    await applyState(
+      {
+        sessions: currentState.sessions.filter(
+          (_session, index) => index !== currentState.activeSessionIndex,
+        ),
+        activeSessionIndex: -1,
+      },
+      {
+        clearExpiredSession: true,
+        error: null,
+        event: {
+          type: 'logout',
+          session,
+        },
+      },
+    );
   }
 
   async function logoutAll(): Promise<void> {
+    await initialize();
     const currentState = await loadAuthState();
 
     await Promise.all(
-      currentState.sessions.map(async (session: AuthSession) => {
+      currentState.sessions.map(async (session) => {
         try {
           await authLogout({
             client,
@@ -404,26 +656,44 @@ export function createAuth(config: AuthConfig = {}): Auth {
             throwOnError: true,
           });
         } catch {
-          // Log but continue
+          // Continue clearing local sessions even if API logout fails.
         }
       }),
     );
 
-    await saveAuthState({ sessions: [], activeSessionIndex: -1 });
-    notifyErrorListeners(null);
+    await applyState(
+      {
+        sessions: [],
+        activeSessionIndex: -1,
+      },
+      {
+        clearExpiredSession: true,
+        error: null,
+        event: {
+          type: 'logout-all',
+        },
+      },
+    );
   }
 
   async function refresh(): Promise<void> {
-    if (refreshPromise) return refreshPromise;
+    if (refreshPromise) {
+      return refreshPromise;
+    }
 
     refreshPromise = (async () => {
       isRefreshing = true;
+      notifyAll();
+
+      let sessionBeforeRefresh: AuthSession | null = null;
+
       try {
         const currentState = await loadAuthState();
         const idx = currentState.activeSessionIndex;
-        const session = currentState.sessions[idx];
+        const session = getActiveSessionFromState(currentState);
+        sessionBeforeRefresh = session;
 
-        if (!session?.token || !session?.refresh_token) {
+        if (idx < 0 || !session?.token || !session.refresh_token) {
           throw new Error('No active session, token, or refresh token found');
         }
 
@@ -435,33 +705,60 @@ export function createAuth(config: AuthConfig = {}): Auth {
         });
         const data = result?.data ?? result;
 
-        const updatedSessions = [...currentState.sessions];
+        const updatedSessions = cloneSessions(currentState.sessions);
         updatedSessions[idx] = {
           ...session,
-          refresh_token: data.refresh_token,
-          expires: data.expires,
+          token: data.token ?? session.token,
+          refresh_token: data.refresh_token ?? session.refresh_token,
+          expires: data.expires ?? session.expires,
           session_duration: session.session_duration ?? 900,
-          company: session.company,
+          company: getSessionCompany(session),
         };
 
-        await saveAuthState({ ...currentState, sessions: updatedSessions });
-        notifyErrorListeners(null);
+        await applyState(
+          {
+            sessions: updatedSessions,
+            activeSessionIndex: idx,
+          },
+          {
+            clearExpiredSession: true,
+            error: null,
+            event: {
+              type: 'refresh',
+              session: updatedSessions[idx],
+            },
+          },
+        );
       } catch (e) {
         const error = e instanceof ApiError ? e : new Error('Refresh failed');
-        notifyErrorListeners(error);
-
         const currentState = await loadAuthState();
-        await saveAuthState({
-          ...currentState,
-          sessions: currentState.sessions.filter(
-            (_: AuthSession, i: number) => i !== currentState.activeSessionIndex,
-          ),
-          activeSessionIndex: -1,
-        });
+        const expiredSession =
+          sessionBeforeRefresh ??
+          getActiveSessionFromState(currentState);
+        const nextSessions = currentState.sessions.filter(
+          (_session, index) => index !== currentState.activeSessionIndex,
+        );
+
+        await applyState(
+          {
+            sessions: nextSessions,
+            activeSessionIndex: -1,
+          },
+          {
+            expiredSession: expiredSession ?? null,
+            error,
+            event: {
+              type: 'session-expired',
+              session: expiredSession,
+              error,
+            },
+          },
+        );
         throw e;
       } finally {
         isRefreshing = false;
         refreshPromise = null;
+        notifyAll();
       }
     })();
 
@@ -469,11 +766,15 @@ export function createAuth(config: AuthConfig = {}): Auth {
   }
 
   async function getToken(): Promise<string | undefined> {
-    if (permanentToken) return permanentToken;
+    if (permanentToken) {
+      return permanentToken;
+    }
 
     await initialize();
     const session = getActiveSession();
-    if (!session) return undefined;
+    if (!session) {
+      return undefined;
+    }
 
     if (session.expires && isTokenExpired(session.expires)) {
       try {
@@ -491,17 +792,34 @@ export function createAuth(config: AuthConfig = {}): Auth {
     userId: string,
     company?: string,
   ): Promise<AuthSession | null> {
+    await initialize();
     const currentState = await loadAuthState();
     const idx = currentState.sessions.findIndex(
-      (s: AuthSession) => s.user.id === userId && s.company === company,
+      (session) =>
+        session.user.id === userId && getSessionCompany(session) === company,
     );
 
-    if (idx === -1) return null;
+    if (idx === -1) {
+      return null;
+    }
 
-    const session = currentState.sessions[idx];
-    await saveAuthState({ ...currentState, activeSessionIndex: idx });
+    await applyState(
+      {
+        sessions: currentState.sessions,
+        activeSessionIndex: idx,
+      },
+      {
+        clearExpiredSession: true,
+        error: null,
+        event: {
+          type: 'session-switched',
+          session: currentState.sessions[idx],
+        },
+      },
+    );
 
-    if (session.expires && isTokenExpired(session.expires)) {
+    const session = getActiveSession();
+    if (session?.expires && isTokenExpired(session.expires)) {
       await refresh();
       return getActiveSession();
     }
@@ -510,23 +828,242 @@ export function createAuth(config: AuthConfig = {}): Auth {
   }
 
   async function clearAllSessions(): Promise<void> {
-    await saveAuthState({ sessions: [], activeSessionIndex: -1 });
-    notifyErrorListeners(null);
+    await initialize();
+    await applyState(
+      {
+        sessions: [],
+        activeSessionIndex: -1,
+      },
+      {
+        clearExpiredSession: true,
+        error: null,
+        event: {
+          type: 'session-cleared',
+        },
+      },
+    );
   }
 
   async function deleteChallenge(challengeId: string): Promise<void> {
+    await initialize();
     const currentState = await loadAuthState();
     const idx = currentState.activeSessionIndex;
-    if (idx < 0 || idx >= currentState.sessions.length) return;
+
+    if (idx < 0 || idx >= currentState.sessions.length) {
+      return;
+    }
 
     const session = currentState.sessions[idx];
-    const updatedSessions = [...currentState.sessions];
+    const updatedSessions = cloneSessions(currentState.sessions);
     updatedSessions[idx] = {
       ...session,
-      challenges: session.challenges?.filter((c: any) => c.id !== challengeId) || [],
+      challenges:
+        session.challenges?.filter((challenge: any) => challenge.id !== challengeId) ||
+        [],
     };
 
-    await saveAuthState({ ...currentState, sessions: updatedSessions });
+    await applyState(
+      {
+        sessions: updatedSessions,
+        activeSessionIndex: idx,
+      },
+      {
+        error: null,
+      },
+    );
+  }
+
+  async function importToken(
+    token: string,
+    options: ImportTokenOptions = {},
+  ): Promise<AuthSession> {
+    await initialize();
+    const user = await fetchUserForToken(token);
+    const sessionDuration = options.sessionDuration ?? 900;
+
+    return upsertSession(
+      {
+        user,
+        token,
+        refresh_token: '',
+        challenges: [],
+        expires: options.expires ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
+        session_duration: sessionDuration,
+        company: options.company ?? user?.company,
+      },
+      'session-imported',
+    );
+  }
+
+  async function validateActiveSession(
+    options: ValidateSessionOptions = {},
+  ): Promise<boolean> {
+    await initialize();
+    const activeSession = getActiveSession();
+
+    if (!activeSession?.token) {
+      return false;
+    }
+
+    const retryCount = options.retryCount ?? 1;
+    const retryDelayMs = options.retryDelayMs ?? 400;
+
+    for (let attempt = 0; attempt <= retryCount; attempt += 1) {
+      try {
+        await fetchUserForToken(activeSession.token);
+        return true;
+      } catch (error) {
+        const status =
+          error instanceof ApiError
+            ? error.status
+            : typeof error === 'object' &&
+                error &&
+                'status' in error &&
+                typeof (error as any).status === 'number'
+              ? (error as any).status
+              : undefined;
+
+        if (status === 401 || status === 403) {
+          if (attempt < retryCount) {
+            await sleep(retryDelayMs);
+            continue;
+          }
+          return false;
+        }
+
+        if (attempt < retryCount) {
+          await sleep(retryDelayMs);
+          continue;
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async function syncActiveSessionUser(): Promise<AuthSession | null> {
+    await initialize();
+    const currentState = await loadAuthState();
+    const idx = currentState.activeSessionIndex;
+    const session = getActiveSessionFromState(currentState);
+
+    if (idx < 0 || !session?.token) {
+      return null;
+    }
+
+    const user = await fetchUserForToken(session.token);
+    const updatedSession: AuthSession = {
+      ...session,
+      user: {
+        ...session.user,
+        ...user,
+      },
+      company: user?.company ?? getSessionCompany(session),
+    };
+
+    const updatedSessions = cloneSessions(currentState.sessions);
+    updatedSessions[idx] = updatedSession;
+
+    await applyState(
+      {
+        sessions: updatedSessions,
+        activeSessionIndex: idx,
+      },
+      {
+        error: null,
+        event: {
+          type: 'session-updated',
+          session: updatedSession,
+        },
+      },
+    );
+
+    return updatedSession;
+  }
+
+  async function updateSession(
+    userId: string,
+    company: string | undefined,
+    patch: SessionPatch,
+  ): Promise<AuthSession | null> {
+    await initialize();
+    const currentState = await loadAuthState();
+    const idx = currentState.sessions.findIndex(
+      (session) =>
+        session.user.id === userId && getSessionCompany(session) === company,
+    );
+
+    if (idx === -1) {
+      return null;
+    }
+
+    const currentSession = currentState.sessions[idx];
+    const updatedSession =
+      typeof patch === 'function'
+        ? patch(currentSession)
+        : {
+            ...currentSession,
+            ...patch,
+            user: patch.user
+              ? {
+                  ...currentSession.user,
+                  ...patch.user,
+                }
+              : currentSession.user,
+            company:
+              patch.company ??
+              patch.user?.company ??
+              getSessionCompany(currentSession),
+          };
+
+    const updatedSessions = cloneSessions(currentState.sessions);
+    updatedSessions[idx] = updatedSession;
+
+    await applyState(
+      {
+        sessions: updatedSessions,
+        activeSessionIndex: currentState.activeSessionIndex,
+      },
+      {
+        error: null,
+        event: {
+          type: 'session-updated',
+          session: updatedSession,
+        },
+      },
+    );
+
+    return updatedSession;
+  }
+
+  async function expireActiveSession(): Promise<AuthRecoveryState> {
+    await initialize();
+    const currentState = await loadAuthState();
+    const session = getActiveSessionFromState(currentState);
+
+    if (!session) {
+      return buildRecoveryState(currentState);
+    }
+
+    const nextState: AuthState = {
+      sessions: currentState.sessions.filter(
+        (_entry, index) => index !== currentState.activeSessionIndex,
+      ),
+      activeSessionIndex: -1,
+    };
+
+    await applyState(nextState, {
+      expiredSession: session,
+      error: null,
+      event: {
+        type: 'session-expired',
+        session,
+      },
+    });
+
+    return buildRecoveryState();
   }
 
   return {
@@ -538,22 +1075,42 @@ export function createAuth(config: AuthConfig = {}): Auth {
     refresh,
     getToken,
     getActiveSession,
-    getSessions: () => [...sessions],
+    getSessions: () => cloneSessions(sessions),
     getSessionsByCompany: (company: string) =>
-      sessions.filter((s) => s.company === company),
+      sessions.filter((session) => getSessionCompany(session) === company),
+    getState,
+    getStatus: () => getStatus(),
+    getRecoveryState: () => buildRecoveryState(),
     switchToSession,
     clearAllSessions,
     deleteChallenge,
+    importToken,
+    validateActiveSession,
+    syncActiveSessionUser,
+    updateSession,
+    expireActiveSession,
     subscribe(listener: SessionListener): () => void {
       sessionListeners.push(listener);
       return () => {
-        sessionListeners = sessionListeners.filter((l) => l !== listener);
+        sessionListeners = sessionListeners.filter((entry) => entry !== listener);
       };
     },
     subscribeToErrors(listener: ErrorListener): () => void {
       errorListeners.push(listener);
       return () => {
-        errorListeners = errorListeners.filter((l) => l !== listener);
+        errorListeners = errorListeners.filter((entry) => entry !== listener);
+      };
+    },
+    subscribeToState(listener: AuthStateListener): () => void {
+      stateListeners.push(listener);
+      return () => {
+        stateListeners = stateListeners.filter((entry) => entry !== listener);
+      };
+    },
+    subscribeToEvents(listener: AuthEventListener): () => void {
+      eventListeners.push(listener);
+      return () => {
+        eventListeners = eventListeners.filter((entry) => entry !== listener);
       };
     },
     get baseUrl() {

--- a/src/auth/create-auth.ts
+++ b/src/auth/create-auth.ts
@@ -178,6 +178,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
   let loadAuthStatePromise: Promise<AuthState> | null = null;
   let initialized = false;
   let initializePromise: Promise<void> | null = null;
+  let cachedSnapshot: AuthSnapshot | null = null;
   let lastError: Error | null = null;
   let lastExpiredSession: AuthSession | null = null;
 
@@ -237,8 +238,11 @@ export function createAuth(config: AuthConfig = {}): Auth {
   }
 
   function getState(): AuthSnapshot {
+    if (cachedSnapshot) {
+      return cachedSnapshot;
+    }
     const state = getCurrentState();
-    return {
+    cachedSnapshot = {
       status: getStatus(state),
       session: getActiveSessionFromState(state),
       sessions: state.sessions,
@@ -248,6 +252,11 @@ export function createAuth(config: AuthConfig = {}): Auth {
       error: lastError,
       recovery: buildRecoveryState(state),
     };
+    return cachedSnapshot;
+  }
+
+  function invalidateSnapshot(): void {
+    cachedSnapshot = null;
   }
 
   function emit(event: Omit<AuthEvent, 'snapshot'>): void {
@@ -260,6 +269,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
   }
 
   function notifyAll(event?: Omit<AuthEvent, 'snapshot'>): void {
+    invalidateSnapshot();
     const snapshot = getState();
     sessionListeners.forEach((listener) => listener(snapshot.session));
     errorListeners.forEach((listener) => listener(snapshot.error));

--- a/src/auth/create-auth.ts
+++ b/src/auth/create-auth.ts
@@ -899,16 +899,21 @@ export function createAuth(config: AuthConfig = {}): Auth {
     options: ValidateSessionOptions = {},
   ): Promise<boolean> {
     await initialize();
-    const activeSession = getActiveSession();
-
-    if (!activeSession?.token) {
+    if (!getActiveSession()?.token) {
       return false;
     }
 
     const retryCount = options.retryCount ?? 1;
     const retryDelayMs = options.retryDelayMs ?? 400;
+    let refreshAttempted = false;
 
     for (let attempt = 0; attempt <= retryCount; attempt += 1) {
+      const activeSession = getActiveSession();
+
+      if (!activeSession?.token) {
+        return false;
+      }
+
       try {
         await fetchUserForToken(activeSession.token);
         return true;
@@ -924,6 +929,28 @@ export function createAuth(config: AuthConfig = {}): Auth {
               : undefined;
 
         if (status === 401 || status === 403) {
+          if (!refreshAttempted && activeSession.refresh_token) {
+            refreshAttempted = true;
+
+            try {
+              await refresh();
+            } catch {
+              return false;
+            }
+
+            const refreshedSession = getActiveSession();
+            if (!refreshedSession?.token) {
+              return false;
+            }
+
+            try {
+              await fetchUserForToken(refreshedSession.token);
+              return true;
+            } catch {
+              return false;
+            }
+          }
+
           if (attempt < retryCount) {
             await sleep(retryDelayMs);
             continue;

--- a/src/auth/create-auth.ts
+++ b/src/auth/create-auth.ts
@@ -935,6 +935,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
             try {
               await refresh();
             } catch {
+              await expireActiveSession();
               return false;
             }
 
@@ -947,6 +948,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
               await fetchUserForToken(refreshedSession.token);
               return true;
             } catch {
+              await expireActiveSession();
               return false;
             }
           }
@@ -955,6 +957,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
             await sleep(retryDelayMs);
             continue;
           }
+          await expireActiveSession();
           return false;
         }
 
@@ -963,7 +966,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
           continue;
         }
 
-        return true;
+        return false;
       }
     }
 

--- a/src/auth/create-auth.ts
+++ b/src/auth/create-auth.ts
@@ -177,6 +177,7 @@ export function createAuth(config: AuthConfig = {}): Auth {
   let isRefreshing = false;
   let loadAuthStatePromise: Promise<AuthState> | null = null;
   let initialized = false;
+  let initializePromise: Promise<void> | null = null;
   let lastError: Error | null = null;
   let lastExpiredSession: AuthSession | null = null;
 
@@ -399,16 +400,22 @@ export function createAuth(config: AuthConfig = {}): Auth {
     if (initialized) {
       return;
     }
-    initialized = true;
-
-    if (!permanentToken) {
-      if (enableCrossTabSync) {
-        setupCrossTabSync();
-      }
-      await loadAuthState();
+    if (initializePromise) {
+      return initializePromise;
     }
 
-    notifyAll({ type: 'initialized' });
+    initializePromise = (async () => {
+      if (!permanentToken) {
+        if (enableCrossTabSync) {
+          setupCrossTabSync();
+        }
+        await loadAuthState();
+      }
+      initialized = true;
+      notifyAll({ type: 'initialized' });
+    })();
+
+    return initializePromise;
   }
 
   async function fetchUserForToken(token: string): Promise<any> {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,27 @@
 export { createAuth } from './create-auth.js';
-export type { Auth, AuthConfig, LoginParams, RegisterParams, RegisterCompanyParams } from './create-auth.js';
-export type { AuthSession, UserSession, AuthState, SessionListener, ErrorListener, StorageAdapter } from './types/index.js';
+export type {
+  Auth,
+  AuthConfig,
+  LoginParams,
+  RegisterParams,
+  RegisterCompanyParams,
+  ImportTokenOptions,
+  ValidateSessionOptions,
+  SessionPatch,
+} from './create-auth.js';
+export type {
+  AuthSession,
+  UserSession,
+  AuthState,
+  AuthStatus,
+  AuthRecoveryState,
+  AuthSnapshot,
+  AuthEvent,
+  AuthEventType,
+  SessionListener,
+  ErrorListener,
+  AuthStateListener,
+  AuthEventListener,
+  StorageAdapter,
+} from './types/index.js';
 export { WebStorageAdapter, MemoryStorageAdapter, AsyncStorageAdapter } from './core/storage-adapters.js';

--- a/src/auth/types/index.ts
+++ b/src/auth/types/index.ts
@@ -24,5 +24,53 @@ export interface AuthState {
   activeSessionIndex: number;
 }
 
+export type AuthStatus =
+  | 'loading'
+  | 'authenticated'
+  | 'refreshing'
+  | 'recoverable'
+  | 'unauthenticated';
+
+export interface AuthRecoveryState {
+  pending: boolean;
+  expiredSession: AuthSession | null;
+  remainingSessions: AuthSession[];
+}
+
+export interface AuthSnapshot {
+  status: AuthStatus;
+  session: AuthSession | null;
+  sessions: AuthSession[];
+  activeSessionIndex: number;
+  isRefreshing: boolean;
+  initialized: boolean;
+  error: Error | null;
+  recovery: AuthRecoveryState;
+}
+
+export type AuthEventType =
+  | 'initialized'
+  | 'login'
+  | 'register'
+  | 'register-company'
+  | 'logout'
+  | 'logout-all'
+  | 'refresh'
+  | 'session-imported'
+  | 'session-updated'
+  | 'session-switched'
+  | 'session-expired'
+  | 'session-cleared'
+  | 'error';
+
+export interface AuthEvent {
+  type: AuthEventType;
+  snapshot: AuthSnapshot;
+  session?: AuthSession | null;
+  error?: Error | null;
+}
+
 export type SessionListener = (session: AuthSession | null) => void;
 export type ErrorListener = (error: Error | null) => void;
+export type AuthStateListener = (snapshot: AuthSnapshot) => void;
+export type AuthEventListener = (event: AuthEvent) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,14 @@
 export { createAuth } from './auth/create-auth.js';
-export type { Auth, AuthConfig, LoginParams, RegisterParams, RegisterCompanyParams } from './auth/create-auth.js';
+export type {
+  Auth,
+  AuthConfig,
+  LoginParams,
+  RegisterParams,
+  RegisterCompanyParams,
+  ImportTokenOptions,
+  ValidateSessionOptions,
+  SessionPatch,
+} from './auth/create-auth.js';
 
 export { createUserApi } from './platform/user/create-api.js';
 export { createAdminApi } from './platform/admin/create-api.js';
@@ -13,7 +22,14 @@ export type {
   UserSession,
   AuthSession,
   AuthState,
+  AuthStatus,
+  AuthRecoveryState,
+  AuthSnapshot,
+  AuthEvent,
+  AuthEventType,
   SessionListener,
   ErrorListener,
+  AuthStateListener,
+  AuthEventListener,
   StorageAdapter,
 } from './auth/types/index.js';

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -4,12 +4,21 @@ export type { AuthContextType, AuthProviderProps } from './react/auth-provider.j
 export type {
   UserSession,
   AuthSession,
+  AuthStatus,
+  AuthRecoveryState,
+  AuthSnapshot,
+  AuthEvent,
   SessionListener,
   ErrorListener,
+  AuthStateListener,
+  AuthEventListener,
 } from './auth/types/index.js';
 
 export type {
   LoginParams,
   RegisterParams,
   RegisterCompanyParams,
+  ImportTokenOptions,
+  ValidateSessionOptions,
+  SessionPatch,
 } from './auth/create-auth.js';

--- a/src/react/auth-provider.tsx
+++ b/src/react/auth-provider.tsx
@@ -1,10 +1,34 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
 import { createAuth } from '../auth/create-auth.js';
-import type { Auth, AuthConfig, LoginParams, RegisterParams, RegisterCompanyParams } from '../auth/create-auth.js';
-import type { AuthSession } from '../auth/types/index.js';
+import type {
+  Auth,
+  AuthConfig,
+  ImportTokenOptions,
+  LoginParams,
+  RegisterParams,
+  RegisterCompanyParams,
+  SessionPatch,
+  ValidateSessionOptions,
+} from '../auth/create-auth.js';
+import type {
+  AuthRecoveryState,
+  AuthSession,
+  AuthSnapshot,
+  AuthStatus,
+} from '../auth/types/index.js';
 
 export interface AuthContextType {
   authUser: AuthSession | null | undefined;
+  authStatus: AuthStatus;
+  authState: AuthSnapshot;
+  authRecovery: AuthRecoveryState;
   refreshCallback: () => Promise<void>;
   login: (params: LoginParams) => Promise<AuthSession>;
   register: (params: RegisterParams) => Promise<AuthSession>;
@@ -19,6 +43,15 @@ export interface AuthContextType {
   switchToSession: (userId: string, company?: string) => Promise<AuthSession | null>;
   clearAllSessions: () => Promise<void>;
   logoutAll: () => Promise<void>;
+  importToken: (token: string, options?: ImportTokenOptions) => Promise<AuthSession>;
+  validateActiveSession: (options?: ValidateSessionOptions) => Promise<boolean>;
+  syncActiveSessionUser: () => Promise<AuthSession | null>;
+  updateSession: (
+    userId: string,
+    company: string | undefined,
+    patch: SessionPatch,
+  ) => Promise<AuthSession | null>;
+  expireActiveSession: () => Promise<AuthRecoveryState>;
   auth: Auth;
 }
 
@@ -31,124 +64,122 @@ export interface AuthProviderProps {
 
 export const AuthProvider = ({ children, config }: AuthProviderProps) => {
   const [auth] = useState(() => createAuth(config));
-  const [authUser, setAuthUser] = useState<AuthSession | null | undefined>(undefined);
-  const [authLoading, setAuthLoading] = useState(true);
-  const [authError, setAuthError] = useState<Error | null>(null);
+  const [authState, setAuthState] = useState<AuthSnapshot>(() => auth.getState());
+  const [pendingActionCount, setPendingActionCount] = useState(0);
 
-  const refreshCallback = useCallback(() => auth.refresh(), [auth]);
+  const runWithLoading = useCallback(
+    async function <T>(operation: () => Promise<T>): Promise<T> {
+      setPendingActionCount((count) => count + 1);
+      try {
+        return await operation();
+      } finally {
+        setPendingActionCount((count) => Math.max(0, count - 1));
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
-    const unsubscribeSession = auth.subscribe(setAuthUser);
-    const unsubscribeError = auth.subscribeToErrors(setAuthError);
-
+    const unsubscribeState = auth.subscribeToState(setAuthState);
     return () => {
-      unsubscribeSession();
-      unsubscribeError();
+      unsubscribeState();
     };
   }, [auth]);
 
-  useEffect(() => {
-    const initializeAuth = async () => {
-      try {
-        if (!config.token) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-        const session = auth.getActiveSession();
-        setAuthUser(session);
-      } catch (error) {
-        console.error('Error initializing auth:', error);
-        setAuthUser(null);
-      } finally {
-        setAuthLoading(false);
+  const refreshCallback = useCallback(() => auth.refresh(), [auth]);
+
+  const login = useCallback(
+    (params: LoginParams): Promise<AuthSession> =>
+      runWithLoading(() => auth.login(params)),
+    [auth, runWithLoading],
+  );
+
+  const register = useCallback(
+    (params: RegisterParams): Promise<AuthSession> =>
+      runWithLoading(() => auth.register(params)),
+    [auth, runWithLoading],
+  );
+
+  const registerCompany = useCallback(
+    (params: RegisterCompanyParams): Promise<AuthSession> =>
+      runWithLoading(() => auth.registerCompany(params)),
+    [auth, runWithLoading],
+  );
+
+  const logout = useCallback(
+    (): Promise<void> => runWithLoading(() => auth.logout()),
+    [auth, runWithLoading],
+  );
+
+  const deleteChallenge = useCallback(
+    async (challengeId: string | undefined): Promise<void> => {
+      if (!challengeId) {
+        return;
       }
-    };
+      await runWithLoading(() => auth.deleteChallenge(challengeId));
+    },
+    [auth, runWithLoading],
+  );
 
-    initializeAuth();
-  }, [auth, config.token]);
+  const switchToSession = useCallback(
+    (userId: string, company?: string): Promise<AuthSession | null> =>
+      runWithLoading(() => auth.switchToSession(userId, company)),
+    [auth, runWithLoading],
+  );
 
-  const login = async (params: LoginParams): Promise<AuthSession> => {
-    setAuthLoading(true);
-    try {
-      return await auth.login(params);
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const clearAllSessions = useCallback(
+    (): Promise<void> => runWithLoading(() => auth.clearAllSessions()),
+    [auth, runWithLoading],
+  );
 
-  const register = async (params: RegisterParams): Promise<AuthSession> => {
-    setAuthLoading(true);
-    try {
-      return await auth.register(params);
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const logoutAll = useCallback(
+    (): Promise<void> => runWithLoading(() => auth.logoutAll()),
+    [auth, runWithLoading],
+  );
 
-  const registerCompany = async (params: RegisterCompanyParams): Promise<AuthSession> => {
-    setAuthLoading(true);
-    try {
-      return await auth.registerCompany(params);
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const importToken = useCallback(
+    (token: string, options?: ImportTokenOptions): Promise<AuthSession> =>
+      runWithLoading(() => auth.importToken(token, options)),
+    [auth, runWithLoading],
+  );
 
-  const logout = async (): Promise<void> => {
-    setAuthLoading(true);
-    try {
-      await auth.logout();
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const validateActiveSession = useCallback(
+    (options?: ValidateSessionOptions): Promise<boolean> =>
+      auth.validateActiveSession(options),
+    [auth],
+  );
 
-  const deleteChallenge = async (challengeId: string | undefined): Promise<void> => {
-    if (!challengeId) return;
-    setAuthLoading(true);
-    try {
-      await auth.deleteChallenge(challengeId);
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const syncActiveSessionUser = useCallback(
+    (): Promise<AuthSession | null> => runWithLoading(() => auth.syncActiveSessionUser()),
+    [auth, runWithLoading],
+  );
 
-  const getSessions = (): AuthSession[] => auth.getSessions();
+  const updateSession = useCallback(
+    (
+      userId: string,
+      company: string | undefined,
+      patch: SessionPatch,
+    ): Promise<AuthSession | null> =>
+      runWithLoading(() => auth.updateSession(userId, company, patch)),
+    [auth, runWithLoading],
+  );
 
-  const getSessionsByCompany = (company: string): AuthSession[] =>
-    auth.getSessionsByCompany(company);
+  const expireActiveSession = useCallback(
+    (): Promise<AuthRecoveryState> =>
+      runWithLoading(() => auth.expireActiveSession()),
+    [auth, runWithLoading],
+  );
 
-  const switchToSession = async (
-    userId: string,
-    company?: string,
-  ): Promise<AuthSession | null> => {
-    setAuthLoading(true);
-    try {
-      return await auth.switchToSession(userId, company);
-    } finally {
-      setAuthLoading(false);
-    }
-  };
-
-  const clearAllSessions = async (): Promise<void> => {
-    setAuthLoading(true);
-    try {
-      await auth.clearAllSessions();
-    } finally {
-      setAuthLoading(false);
-    }
-  };
-
-  const logoutAll = async (): Promise<void> => {
-    setAuthLoading(true);
-    try {
-      await auth.logoutAll();
-    } finally {
-      setAuthLoading(false);
-    }
-  };
+  const authLoading =
+    pendingActionCount > 0 ||
+    authState.status === 'loading' ||
+    authState.status === 'refreshing';
 
   const contextValue: AuthContextType = {
-    authUser,
+    authUser: authState.session,
+    authStatus: authState.status,
+    authState,
+    authRecovery: authState.recovery,
     refreshCallback,
     login,
     register,
@@ -156,13 +187,18 @@ export const AuthProvider = ({ children, config }: AuthProviderProps) => {
     logout,
     refresh: refreshCallback,
     authLoading,
-    authError,
+    authError: authState.error,
     deleteChallenge,
-    getSessions,
-    getSessionsByCompany,
+    getSessions: auth.getSessions,
+    getSessionsByCompany: auth.getSessionsByCompany,
     switchToSession,
     clearAllSessions,
     logoutAll,
+    importToken,
+    validateActiveSession,
+    syncActiveSessionUser,
+    updateSession,
+    expireActiveSession,
     auth,
   };
 

--- a/src/react/auth-provider.tsx
+++ b/src/react/auth-provider.tsx
@@ -176,7 +176,7 @@ export const AuthProvider = ({ children, config }: AuthProviderProps) => {
     authState.status === 'refreshing';
 
   const contextValue: AuthContextType = {
-    authUser: authState.session,
+    authUser: authState.initialized ? authState.session : undefined,
     authStatus: authState.status,
     authState,
     authRecovery: authState.recovery,

--- a/src/react/auth-provider.tsx
+++ b/src/react/auth-provider.tsx
@@ -2,8 +2,8 @@ import {
   createContext,
   useContext,
   useState,
-  useEffect,
   useCallback,
+  useSyncExternalStore,
   type ReactNode,
 } from 'react';
 import { createAuth } from '../auth/create-auth.js';
@@ -64,8 +64,14 @@ export interface AuthProviderProps {
 
 export const AuthProvider = ({ children, config }: AuthProviderProps) => {
   const [auth] = useState(() => createAuth(config));
-  const [authState, setAuthState] = useState<AuthSnapshot>(() => auth.getState());
   const [pendingActionCount, setPendingActionCount] = useState(0);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => auth.subscribeToState(() => onStoreChange()),
+    [auth],
+  );
+  const getSnapshot = useCallback((): AuthSnapshot => auth.getState(), [auth]);
+  const authState = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const runWithLoading = useCallback(
     async function <T>(operation: () => Promise<T>): Promise<T> {
@@ -78,13 +84,6 @@ export const AuthProvider = ({ children, config }: AuthProviderProps) => {
     },
     [],
   );
-
-  useEffect(() => {
-    const unsubscribeState = auth.subscribeToState(setAuthState);
-    return () => {
-      unsubscribeState();
-    };
-  }, [auth]);
 
   const refreshCallback = useCallback(() => auth.refresh(), [auth]);
 


### PR DESCRIPTION
## Summary
- Merges `codex/auth-lifecycle-recovery-sdk` into master. 4.2.0 was already published from that branch, so its commits need to land on master.
- Brings in: auth lifecycle + recovery APIs, refresh-before-expire behavior, `useSyncExternalStore` subscription, deferred `initialized` flag until hydration, and `validateActiveSession` failure handling.

## Conflict resolution
- **`package.json`**: kept `4.2.1` (master's bump — 4.2.0 already taken on npm).
- **`src/auth/create-auth.ts`**:
  - `login` / `register`: adopted codex's `upsertSession` helper while preserving PR #53's `session_duration ?? 900` storage default.
  - `refresh`: took codex's null-safe field updates (`data.token ?? session.token`, etc.) and `getSessionCompany(session)`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 54/54 passing
- [ ] CI green